### PR TITLE
Trailing '+' is a syntax error

### DIFF
--- a/Python/cloud_function/__main__.py
+++ b/Python/cloud_function/__main__.py
@@ -47,7 +47,7 @@ def main(args):
     result_location = sqlClient.get_job(jobId)['resultset_location']
 
     access_code = 'import ibmcloudsql\n'
-    access_code += 'sqlClient = ibmcloudsql.SQLQuery(' + ibmcloud_apikey + ', ' + sql_instance_crn + ', ' + target_url + ')\n' +
+    access_code += 'sqlClient = ibmcloudsql.SQLQuery(' + ibmcloud_apikey + ', ' + sql_instance_crn + ', ' + target_url + ')\n'
     access_code += 'sqlClient.logon()\n'
     access_code += 'result_df = sqlClient.get_result(' + jobId + ')\n'
 


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/IBM-Cloud/sql-query-clients on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./Python/cloud_function/__main__.py:50:128: E999 SyntaxError: invalid syntax
    access_code += 'sqlClient = ibmcloudsql.SQLQuery(' + ibmcloud_apikey + ', ' + sql_instance_crn + ', ' + target_url + ')\n' +
                                                                                                                               ^
1     E999 SyntaxError: invalid syntax
1
```