### PR TITLE
Implements pagination using PARTITIONED statements

### DIFF
--- a/Python/ibmcloudsql/SQLQuery.py
+++ b/Python/ibmcloudsql/SQLQuery.py
@@ -169,10 +169,8 @@ class SQLQuery():
         # Second, the data could be partitioned into buckets
         m = re.match(r'.*PARTITIONED\s+INTO\s+(\d+)\s+BUCKETS.*', statement, re.MULTILINE | re.DOTALL)
         if m is not None:
-            print("Partitioned into {} buckets".format(m.groups()[0]))
+            # print("Partitioned into {} buckets".format(m.groups()[0]))
             return None
-            # return int(m.groups()[0])
-
         # Third, find the columns being partitioned
         m = re.match(r'.*PARTITIONED\s+BY\s+\(([a-z,]+)\).*', statement, re.MULTILINE | re.DOTALL)
         partitioned_by = None
@@ -290,9 +288,8 @@ class SQLQuery():
         if 'start_rec' in kwargs or 'end_rec' in kwargs:
             cut_front = start_rec - start_partition * units
             cut_back = end_rec - min(end_partition * units, rows_returned) + 1
-            print("End Rec: {} End Partition {} Rows Returned {} Units {}".format(end_rec, end_partition, rows_returned, units))
-            print("Cut from front: %d and back %d" % (cut_front, cut_back))
-            print(result_df)
+            # print("End Rec: {} End Partition {} Rows Returned {} Units {}".format(end_rec, end_partition, rows_returned, units))
+            # print("Cut from front: %d and back %d" % (cut_front, cut_back))
             result_df.drop(result_df.index[range(cut_front)], inplace=True)
             result_df.drop(result_df.index[range(cut_back,0)], inplace=True)
         return result_df


### PR DESCRIPTION
Implements pagination for queries. 

The `get_result()` method takes two optional parameters, `start_rec` and `end_rec` for the first and last records in the result to return. This PR attempts to make this more efficient by not loading all data.

When a query has been partitioned, there are three options: 

1. `PARTITIONED EVERY <n> ROWS`
1. `PARTITIONED INTO <n> BUCKETS` 
1. `PARTITIONED BY <row>`

In the first case, we only load the partitions that contain rows to be returned. We load an entire partition, and remove the undesired rows. The second case we cannot guarantee the rows are evenly distributed, and leave it as future work. In the third case, if the rows are partitioned by a `monotonically_increasing_id()` field, then we can try to rely on that for consistent partitioning. The first option, `PARTITIONED EVERY <n> ROWS` is preferable, and the others are included for completeness. Options 2 and 3 are represented in lines 169--183.

Closes #21 