### PR TITLE
Undefined name: Error --> Exception

### DIFF
--- a/Python/cloud_function/__main__.py
+++ b/Python/cloud_function/__main__.py
@@ -41,7 +41,7 @@ def main(args):
     sqlClient.logon()
     try:
         jobId = sqlClient.submit_sql(sql_statement_text)
-    except Error as e:
+    except Exception as e:
         return {'Error': e}
 
     jobDetails = sqlClient.get_job(jobId)

--- a/Python/cloud_function/invoke.py
+++ b/Python/cloud_function/invoke.py
@@ -96,7 +96,7 @@ def init(args):
             contents = fp.read()
         contents = base64.b64encode(contents)
         binary = True
-    elif artifact is not '':
+    elif artifact != '':
         with(codecs.open(artifact, 'r', 'utf-8')) as fp:
             contents = fp.read()
         binary = False


### PR DESCRIPTION
https://docs.python.org/3/library/exceptions.html#Exception

[flake8](http://flake8.pycqa.org) testing of https://github.com/IBM-Cloud/sql-query-clients on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./Python/cloud_function/invoke.py:99:10: F632 use ==/!= to compare str, bytes, and int literals
    elif artifact is not '':
         ^
./Python/cloud_function/__main__.py:44:12: F821 undefined name 'Error'
    except Error as e:
           ^
1     F632 use ==/!= to compare str, bytes, and int literals
1     F821 undefined name 'Error'
2
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree