### PR TITLE
Covers js code in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,24 @@
-language: python
-
-python:
-- '3.7'
-- '2.7'
-
-env:
-  global:
-  - PIPENV_IGNORE_VIRTUALENVS=1
-
-before_install: cd Python
-
-install:
-- pipenv sync --dev
-- pipenv check
-
-script:
-- PYTHONPATH=. pipenv run ci
+matrix:
+  include:
+  - language: node_js
+    node_js:
+    - '8'
+    before_install: cd Node
+  - language: python
+    python: '2.7'
+    env: PIPENV_IGNORE_VIRTUALENVS=1
+    before_install: cd Python
+    install:
+    - pipenv sync --dev
+    - pipenv check
+    script:
+    - PYTHONPATH=. pipenv run ci
+  - language: python
+    python: '3.7'
+    env: PIPENV_IGNORE_VIRTUALENVS=1
+    before_install: cd Python
+    install:
+    - pipenv sync --dev
+    - pipenv check
+    script:
+    - PYTHONPATH=. pipenv run ci

--- a/Node/test/sqlquery_spec.js
+++ b/Node/test/sqlquery_spec.js
@@ -3,9 +3,14 @@ const SqlQuery = require('../');
 
 describe('sqlQuery', () => {
     describe('new', () => {
+        let sqlQuery = new SqlQuery('mock-api-key', 'mock-crn', 'https://');
+
         it('returns object', () => {
-            let sqlQuery = new SqlQuery('mock-api-key', 'mock-crn', 'https://');
-            expect(sqlQuery).to.have.property('runSql');
+            expect(sqlQuery).to.be.a('object');
+        });
+
+        it('has function runSql()', () => {
+            expect(sqlQuery).to.have.property('runSql').to.be.a('function');
         });
     });
 });

--- a/Node/test/sqlquery_spec.js
+++ b/Node/test/sqlquery_spec.js
@@ -1,0 +1,11 @@
+const expect = require('chai').expect;
+const SqlQuery = require('../');
+
+describe('sqlQuery', () => {
+    describe('new', () => {
+        it('returns object', () => {
+            let sqlQuery = new SqlQuery('mock-api-key', 'mock-crn', 'https://');
+            expect(sqlQuery).to.have.property('runSql');
+        });
+    });
+});


### PR DESCRIPTION
This is a follow up of #32 where it covers Python code only.

Notice: the multi-language Travis CI build design comes from this answer on stackoverflow.com: https://stackoverflow.com/a/52108211/914967