### PR TITLE
Alter tornado to requests as runtime dependency

### DIFF
--- a/Python/Pipfile
+++ b/Python/Pipfile
@@ -13,10 +13,7 @@ ibm-cos-sdk = ">=2.4.4"
 numpy = "*"
 pandas = "*"
 pyarrow = "*"
-tornado = "<=4.5.2"
-# Pipenv can not pick them up from tornado so add them explicitly
-singledispatch = {version = "*", markers = "python_version < '3.4'"}
-backports-abc = {version = ">=0.4", markers = "python_version < '3.5'"}
+requests = ">= 2.2.0"
 
 [scripts]
 ci = "pytest"

--- a/Python/Pipfile.lock
+++ b/Python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "df58295c58d2dbb27440ea6bb97d6d9feefcafd73ebaf746e5a94bfd22121b5c"
+            "sha256": "5e8376ac29f5342be5400699d9330580a039326c0473e8a23dbf4c53120a241c"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,21 +14,26 @@
         ]
     },
     "default": {
-        "backports-abc": {
-            "hashes": [
-                "sha256:033be54514a03e255df75c5aee8f9e672f663f93abb723444caec8fe43437bde",
-                "sha256:52089f97fe7a9aa0d3277b220c1d730a85aefd64e1b2664696fe35317c5470a7"
-            ],
-            "index": "pypi",
-            "markers": "python_version < '3.5'",
-            "version": "==0.5"
-        },
         "backports.functools-lru-cache": {
             "hashes": [
                 "sha256:9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a",
                 "sha256:f0b0e4eba956de51238e17573b7087e852dfe9854afd2e9c873f73fc0ca0a6dd"
             ],
             "version": "==1.5"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
+                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+            ],
+            "version": "==2019.6.16"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
         },
         "docutils": {
             "hashes": [
@@ -75,6 +80,13 @@
                 "sha256:90b63ff958068dfdea952e845a25e31d932220108a06afd57987276a53590dab"
             ],
             "version": "==2.5.0"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
         },
         "jmespath": {
             "hashes": [
@@ -171,14 +183,13 @@
             ],
             "version": "==2019.1"
         },
-        "singledispatch": {
+        "requests": {
             "hashes": [
-                "sha256:5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c",
-                "sha256:833b46966687b3de7f438c761ac475213e53b306740f1abfaa86e1d1aae56aa8"
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
             "index": "pypi",
-            "markers": "python_version < '3.4'",
-            "version": "==3.4.0.3"
+            "version": "==2.22.0"
         },
         "six": {
             "hashes": [
@@ -186,17 +197,6 @@
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
             "version": "==1.12.0"
-        },
-        "tornado": {
-            "hashes": [
-                "sha256:1fb8e494cd46c674d86fac5885a3ff87b0e283937a47d74eb3c02a48c9e89ad0",
-                "sha256:2b40720a7b164848ca5c51fab0feac7e3717adcb87bec77f81f7809b72bf7f56",
-                "sha256:62a5d4c66bf4e86d25a02e9de97293860b59e61f9c465e80336ba0fc308aacf6",
-                "sha256:e66f47db4753c6f6849af1f82f04bdc7d2c1f5d64b7cc11ddd17230295c8887f",
-                "sha256:f109c066411c44bcd3bc877267b45feb8e29092ede59dd0582739444c2344b00"
-            ],
-            "index": "pypi",
-            "version": "==4.5.2"
         },
         "urllib3": {
             "hashes": [
@@ -298,11 +298,11 @@
         },
         "pathlib2": {
             "hashes": [
-                "sha256:25199318e8cc3c25dcb45cbe084cc061051336d5a9ea2a12448d3d8cb748f742",
-                "sha256:5887121d7f7df3603bca2f710e7219f3eca0eb69e0b7cc6e0a022e155ac931a7"
+                "sha256:2156525d6576d21c4dcaddfa427fae887ef89a7a9de5cbfe0728b3aafa78427e",
+                "sha256:446014523bb9be5c28128c4d2a10ad6bb60769e78bd85658fe44a450674e0ef8"
             ],
-            "markers": "python_version < '3.6'",
-            "version": "==2.3.3"
+            "markers": "python_version == '3.4.*' or python_version < '3'",
+            "version": "==2.3.4"
         },
         "pluggy": {
             "hashes": [

--- a/Python/ibmcloudsql/SQLQuery.py
+++ b/Python/ibmcloudsql/SQLQuery.py
@@ -19,11 +19,9 @@ import urllib
 import json
 import time
 import xml.etree.ElementTree as ET
-from tornado.escape import json_decode
-from tornado.httpclient import HTTPClient, HTTPError
-from tornado.httputil import HTTPHeaders
 import sys
 import types
+import requests
 import pandas as pd
 import numpy as np
 from ibm_botocore.client import Config
@@ -31,6 +29,7 @@ import ibm_boto3
 from datetime import datetime
 import pyarrow
 import os
+import json
 import tempfile
 
 
@@ -74,13 +73,14 @@ class SQLQuery():
             self.user_agent = 'IBM Cloud SQL Query Python SDK'
         else:
             self.user_agent = client_info
-        self.client = HTTPClient()
-        self.request_headers = HTTPHeaders({'Content-Type': 'application/json'})
-        self.request_headers.add('Accept', 'application/json')
-        self.request_headers.add('User-Agent', self.user_agent)
-        self.request_headers_xml_content = HTTPHeaders({'Content-Type': 'application/x-www-form-urlencoded'})
-        self.request_headers_xml_content.add('Accept', 'application/json')
-        self.request_headers_xml_content.add('User-Agent', self.user_agent)
+
+        self.request_headers = {'Content-Type': 'application/json'}
+        self.request_headers.update({'Accept': 'application/json'})
+        self.request_headers.update({'User-Agent': self.user_agent})
+        self.request_headers_xml_content = {'Content-Type': 'application/x-www-form-urlencoded'}
+        self.request_headers_xml_content.update({'Accept': 'application/json'})
+        self.request_headers_xml_content.update({'User-Agent': self.user_agent})
+
         self.logged_on = False
 
     def logon(self):
@@ -89,25 +89,23 @@ class SQLQuery():
         else:
             data = urllib.urlencode({'grant_type': 'urn:ibm:params:oauth:grant-type:apikey', 'apikey': self.api_key})
 
-        response = self.client.fetch(
+        response = requests.post(
             'https://iam.bluemix.net/identity/token',
-            method='POST',
             headers=self.request_headers_xml_content,
-            validate_cert=False,
-            body=data)
+            data=data)
 
-        if response.code == 200:
+        if response.status_code == 200:
             # print("Authentication successful")
-            bearer_response = json_decode(response.body)
+            bearer_response = response.json()
             self.bearer_token = 'Bearer ' + bearer_response['access_token']
-            self.request_headers = HTTPHeaders({'Content-Type': 'application/json'})
-            self.request_headers.add('Accept', 'application/json')
-            self.request_headers.add('User-Agent', self.user_agent)
-            self.request_headers.add('authorization', self.bearer_token)
+            self.request_headers = {'Content-Type': 'application/json'}
+            self.request_headers.update({'Accept':'application/json'})
+            self.request_headers.update({'User-Agent': self.user_agent})
+            self.request_headers.update({'authorization': self.bearer_token})
             self.logged_on = True
 
         else:
-            print("Authentication failed with http code {}".format(response.code))
+            print("Authentication failed with http code {}".format(response.status_code))
 
     def submit_sql(self, sql_text, pagesize=None):
         if not self.logged_on:
@@ -130,16 +128,14 @@ class SQLQuery():
             sqlData.update({'resultset_target': self.target_cos})
 
         try:
-            response = self.client.fetch(
+            response = requests.post(
                 "https://sql-api.ng.bluemix.net/v2/sql_jobs?instance_crn={}".format(self.instance_crn),
-                method='POST',
                 headers=self.request_headers,
-                validate_cert=False,
-                body=json.dumps(sqlData))
+                json=sqlData)
+            resp = response.json()
+            return resp['job_id']
         except HTTPError as e:
-            raise SyntaxError("SQL submission failed: {}".format(json_decode(e.response.body)['errors'][0]['message']))
-
-        return json_decode(response.body)['job_id']
+            raise SyntaxError("SQL submission failed: {}".format(json.loads(e.response.body)['errors'][0]['message']))
 
     def wait_for_job(self, jobId):
         if not self.logged_on:
@@ -147,14 +143,13 @@ class SQLQuery():
             return "Not logged on"
 
         while True:
-            response = self.client.fetch(
+            response = requests.get(
                 "https://sql-api.ng.bluemix.net/v2/sql_jobs/{}?instance_crn={}".format(jobId, self.instance_crn),
-                method='GET',
                 headers=self.request_headers,
-                validate_cert=False)
+            )
 
-            if response.code == 200 or response.code == 201:
-                status_response = json_decode(response.body)
+            if response.status_code == 200 or response.status_code == 201:
+                status_response = response.json()
                 jobStatus = status_response['status']
                 if jobStatus == 'completed':
                     # print("Job {} has completed successfully".format(jobId))
@@ -164,7 +159,7 @@ class SQLQuery():
                     print("Job {} has failed".format(jobId))
                     break
             else:
-                print("Job status check failed with http code {}".format(response.code))
+                print("Job status check failed with http code {}".format(response.status_code))
                 break
             time.sleep(2)
         return jobStatus
@@ -178,7 +173,7 @@ class SQLQuery():
             return
 
         job_details = self.get_job(jobId)
-        job_status = job_details['status']
+        job_status = job_details.get('status')
         if job_status == 'running':
             raise ValueError('SQL job with jobId {} still running. Come back later.')
         elif job_status != 'completed':
@@ -195,15 +190,14 @@ class SQLQuery():
         if result_format not in ["csv", "parquet"]:
             raise ValueError("Result object format {} currently not supported by get_result().".format(result_format))
 
-        response = self.client.fetch(
+        response = requests.get(
             result_location,
-            method='GET',
             headers=self.request_headers,
-            validate_cert=False)
+        )
 
-        if response.code == 200 or response.code == 201:
+        if response.status_code == 200 or response.status_code == 201:
             ns = {'s3': 'http://s3.amazonaws.com/doc/2006-03-01/'}
-            responseBodyXMLroot = ET.fromstring(response.body)
+            responseBodyXMLroot = ET.fromstring(response.text)
             bucket_objects = []
             # Find result objects with data
             for contents in responseBodyXMLroot.findall('s3:Contents', ns):
@@ -213,7 +207,7 @@ class SQLQuery():
                 #print("Job result for {} stored at: {}".format(jobId, result_object))
         else:
             raise ValueError("Result object listing for job {} at {} failed with http code {}".format(jobId, result_location,
-                                                                                           response.code))
+                                                                                           response.status_code))
 
         cos_client = ibm_boto3.client(service_name='s3',
                                       ibm_api_key_id=self.api_key,
@@ -296,13 +290,12 @@ class SQLQuery():
 
         fourth_slash = result_location.replace('/', 'X', 3).find('/')
 
-        response = self.client.fetch(
+        response = requests.get(
             result_location[:fourth_slash] + '?prefix=' + result_location[fourth_slash + 1:],
-            method='GET',
             headers=self.request_headers,
-            validate_cert=False)
+        )
 
-        if response.code == 200 or response.code == 201:
+        if response.status_code == 200 or response.status_code == 201:
             ns = {'s3': 'http://s3.amazonaws.com/doc/2006-03-01/'}
             responseBodyXMLroot = ET.fromstring(response.body)
             bucket_name = responseBodyXMLroot.find('s3:Name', ns).text
@@ -318,7 +311,7 @@ class SQLQuery():
                 return
         else:
             print("Result object listing for job {} at {} failed with http code {}".format(jobId, result_location,
-                                                                                           response.code))
+                                                                                           response.status_code))
             return
 
         result_objects_df = pd.DataFrame(columns=['ObjectURL', 'Size'])
@@ -344,13 +337,12 @@ class SQLQuery():
 
         fourth_slash = result_location.replace('/', 'X', 3).find('/')
 
-        response = self.client.fetch(
+        response = requests.get(
             result_location[:fourth_slash] + '?prefix=' + result_location[fourth_slash + 1:],
-            method='GET',
-            headers=self.request_headers,
-            validate_cert=False)
+            params=self.request_headers,
+            )
 
-        if response.code == 200 or response.code == 201:
+        if response.status_code == 200 or response.status_code == 201:
             ns = {'s3': 'http://s3.amazonaws.com/doc/2006-03-01/'}
             responseBodyXMLroot = ET.fromstring(response.body)
             bucket_name = responseBodyXMLroot.find('s3:Name', ns).text
@@ -364,7 +356,7 @@ class SQLQuery():
                 return
         else:
             print("Result object listing for job {} at {} failed with http code {}".format(jobId, result_location,
-                                                                                           response.code))
+                                                                                           response.status_code))
             return
 
         cos_client = ibm_boto3.client(service_name='s3',
@@ -387,43 +379,40 @@ class SQLQuery():
             return
 
         try:
-            response = self.client.fetch(
+            response = requests.get(
                 "https://sql-api.ng.bluemix.net/v2/sql_jobs/{}?instance_crn={}".format(jobId, self.instance_crn),
-                method='GET',
                 headers=self.request_headers,
-                validate_cert=False)
+            )
         except HTTPError as e:
-            if e.response.code == 400:
+            if e.response.status_code == 400:
                 raise ValueError("SQL jobId {} unknown".format(jobId))
             else:
                 raise e
 
-        return json_decode(response.body)
+        return response.json()
 
     def get_jobs(self):
         if not self.logged_on:
             print("You are not logged on to IBM Cloud")
             return
 
-        response = self.client.fetch(
+        response = requests.get(
             "https://sql-api.ng.bluemix.net/v2/sql_jobs?instance_crn={}".format(self.instance_crn),
-            method='GET',
-            headers=self.request_headers,
-            validate_cert=False)
-        if response.code == 200 or response.code == 201:
-            job_list = json_decode(response.body)
+            params=self.request_headers,
+            )
+        if response.status_code == 200 or response.status_code == 201:
+            job_list = json.loads(response.body)
             job_list_df = pd.DataFrame(columns=['job_id', 'status', 'user_id', 'statement', 'resultset_location',
                                                 'submit_time', 'end_time', 'rows_read', 'rows_returned', 'bytes_read',
                                                 'error', 'error_message'])
             for job in job_list['jobs']:
-                response = self.client.fetch(
+                response = requests.get(
                     "https://sql-api.ng.bluemix.net/v2/sql_jobs/{}?instance_crn={}".format(job['job_id'],
                                                                                                 self.instance_crn),
-                    method='GET',
-                    headers=self.request_headers,
-                    validate_cert=False)
-                if response.code == 200 or response.code == 201:
-                    job_details = json_decode(response.body)
+                    params=self.request_headers,
+                    )
+                if response.status_code == 200 or response.status_code == 201:
+                    job_details = json.loads(response.body)
                     error = None
                     error_message = None
                     rows_read = None
@@ -457,10 +446,10 @@ class SQLQuery():
                                                        }], ignore_index=True)
                 else:
                     print("Job details retrieval for jobId {} failed with http code {}".format(job['job_id'],
-                                                                                               response.code))
+                                                                                               response.status_code))
                     break
         else:
-            print("Job list retrieval failed with http code {}".format(response.code))
+            print("Job list retrieval failed with http code {}".format(response.status_code))
         return job_list_df
 
     def run_sql(self, sql_text, pagesize=None):

--- a/Python/ibmcloudsql/SQLQuery.py
+++ b/Python/ibmcloudsql/SQLQuery.py
@@ -135,7 +135,7 @@ class SQLQuery():
             resp = response.json()
             return resp['job_id']
         except HTTPError as e:
-            raise SyntaxError("SQL submission failed: {}".format(json.loads(e.response.body)['errors'][0]['message']))
+            raise SyntaxError("SQL submission failed: {}".format(response.json()['errors'][0]['message']))
 
     def wait_for_job(self, jobId):
         if not self.logged_on:
@@ -339,7 +339,7 @@ class SQLQuery():
 
         response = requests.get(
             result_location[:fourth_slash] + '?prefix=' + result_location[fourth_slash + 1:],
-            params=self.request_headers,
+            headers=self.request_headers,
             )
 
         if response.status_code == 200 or response.status_code == 201:
@@ -398,10 +398,10 @@ class SQLQuery():
 
         response = requests.get(
             "https://sql-api.ng.bluemix.net/v2/sql_jobs?instance_crn={}".format(self.instance_crn),
-            params=self.request_headers,
+            headers=self.request_headers,
             )
         if response.status_code == 200 or response.status_code == 201:
-            job_list = json.loads(response.body)
+            job_list = response.json()
             job_list_df = pd.DataFrame(columns=['job_id', 'status', 'user_id', 'statement', 'resultset_location',
                                                 'submit_time', 'end_time', 'rows_read', 'rows_returned', 'bytes_read',
                                                 'error', 'error_message'])
@@ -409,10 +409,10 @@ class SQLQuery():
                 response = requests.get(
                     "https://sql-api.ng.bluemix.net/v2/sql_jobs/{}?instance_crn={}".format(job['job_id'],
                                                                                                 self.instance_crn),
-                    params=self.request_headers,
+                    headers=self.request_headers,
                     )
                 if response.status_code == 200 or response.status_code == 201:
-                    job_details = json.loads(response.body)
+                    job_details = response.json()
                     error = None
                     error_message = None
                     rows_read = None

--- a/Python/ibmcloudsql/SQLQuery.py
+++ b/Python/ibmcloudsql/SQLQuery.py
@@ -16,7 +16,6 @@
 
 import sys
 import urllib
-import json
 import time
 import xml.etree.ElementTree as ET
 import sys
@@ -29,7 +28,6 @@ import ibm_boto3
 from datetime import datetime
 import pyarrow
 import os
-import json
 import tempfile
 
 

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -21,7 +21,7 @@ def readme():
         return f.read()
 
 setup(name='ibmcloudsql',
-      version='0.2.23',
+      version='0.3.0',
       python_requires='>=2.7, <4',
       install_requires=['pandas','requests','ibm-cos-sdk-core','ibm-cos-sdk','numpy',
                         'pyarrow'],

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -23,7 +23,7 @@ def readme():
 setup(name='ibmcloudsql',
       version='0.2.23',
       python_requires='>=2.7, <4',
-      install_requires=['pandas','tornado<=4.5.2','ibm-cos-sdk-core','ibm-cos-sdk','numpy',
+      install_requires=['pandas','requests','ibm-cos-sdk-core','ibm-cos-sdk','numpy',
                         'pyarrow'],
       description='Python client for interacting with IBM Cloud SQL Query service',
       url='https://github.com/IBM-Cloud/sql-query-clients',

--- a/Python/tests/test_sqlquery.py
+++ b/Python/tests/test_sqlquery.py
@@ -5,4 +5,7 @@ from ibmcloudsql import SQLQuery
 def test_init():
     sqlClient = SQLQuery('mock-api-key', 'mock-crn', client_info='ibmcloudsql test')
 
-    assert type(sqlClient.client).__name__ is 'HTTPClient'
+    assert(sqlClient.request_headers == {'Content-Type': 'application/json',
+    'Accept': 'application/json',
+    'User-Agent': sqlClient.user_agent
+    })


### PR DESCRIPTION
Fixes #37 

the below code example from #41 works:

```Python
import os
import ibmcloudsql

API_KEY = os.environ.get('IBMCLOUD_API_KEY')
INSTANCE_CRN = os.environ.get('SQLQUERY_INSTANCE_CRN')
TARGET_COS_URL = 'cos://us-south/xxx/result/'

sqlClient = ibmcloudsql.SQLQuery(API_KEY, INSTANCE_CRN, target_cos_url=TARGET_COS_URL)
sqlClient.logon()

sql = 'SELECT * FROM cos://us-south/xxx/yyy/ WHERE dt = \'2019-06-02\' LIMIT 5'

df = sqlClient.run_sql(sql)

print(df)
```

Notice that it requires a new release `0.3.0`.

## Benefit

1. supports Python 2.7 (tornado v6+ deprecates Python 2.7 before its end of life) even in the future

IMHO, According to an HTTP client library, I kind of like `tornado` better but I'm sure it will iterate faster when building something with `requests` since we know how to improve/refactoring/debug/test python code uses `requests`. Once it starts to deprecate Python 2.7, I suggest revisiting `tornado` since it has huge advantage on async support (python 3 feature).