### PR TITLE
feat: add Exception for rate limiting

### DIFF
--- a/Python/README.md
+++ b/Python/README.md
@@ -49,6 +49,8 @@ You can use IBM Watson Studio with the following [demo notebook](https://datapla
  * `list_cos_objects(cos_url)` Returns a data frame with the list of objects found in the given cos url
  * `export_job_history(cos_url)` Exports new jobs as parquet file to the given cos url
 
+## Exceptions
+ * `RateLimitedException(message)` raised when jobs can't be submitted due to 429 / Plan limit for concurrent queries has been reached
 ## Constructor options
  * `api_key`: IAM API key
  * `instance_crn`: SQL Query instance CRN identifier

--- a/Python/ibmcloudsql/__init__.py
+++ b/Python/ibmcloudsql/__init__.py
@@ -15,3 +15,4 @@
 # ------------------------------------------------------------------------------
 
 from .SQLQuery import SQLQuery
+from .SQLQuery import RateLimitedException

--- a/Python/ibmcloudsql/test.py
+++ b/Python/ibmcloudsql/test.py
@@ -112,7 +112,7 @@ try:
 except SyntaxError as e:
     print(e)
 
-    
+
 print("Running test with paginated JSON target:")
 jobId = sqlClient.submit_sql(
         "WITH orders as (SELECT customerid, named_struct('count', count(orderid), 'orderids', collect_list(orderid)) orders \
@@ -133,8 +133,8 @@ print(result_df_list.head(200))
 result_df = sqlClient.get_result(jobId, pagenumber=2)
 print("jobId {} result page 2 is:".format(jobId))
 print(result_df.head(10))
-    
-    
+
+
 print("Running test with compound method invocation:")
 result_df = sqlClient.run_sql(
 "WITH orders_shipped AS \
@@ -200,3 +200,10 @@ print("jobId {} restults are stored in {}. Result set is:".format(jobId, sqlClie
 print(result_df.head(200))
 print("EU SQL UI Link:")
 sqlClient_eu.sql_ui_link()
+
+print("Force rate limiting:")
+try:
+    for n in range(6):
+        sqlClient.submit_sql("SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS PARQUET".format(test_credentials.result_location))
+except ibmcloudsql.RateLimitedException as e:
+    print("Got rate limited as expected")

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -21,7 +21,7 @@ def readme():
         return f.read()
 
 setup(name='ibmcloudsql',
-      version='0.3.12',
+      version='0.3.13',
       python_requires='>=2.7, <4',
       install_requires=['pandas','requests','ibm-cos-sdk-core','ibm-cos-sdk','numpy',
                         'pyarrow==0.15.1'],


### PR DESCRIPTION
/fixes #59 by adding a specific exception to be raised. E.g. 

```python
try:
    sqlClient.submit_sql("SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS PARQUET".format(test_credentials.result_location))
except ibmcloudsql.RateLimitedException as e:
    print("Got rate limited ")```


Also raise version level