### PR TITLE
fix: export history

### DIFF
--- a/Python/ibmcloudsql/SQLQuery.py
+++ b/Python/ibmcloudsql/SQLQuery.py
@@ -445,10 +445,11 @@ class SQLQuery():
                     if 'rows_returned' in job_details:
                         rows_returned = job_details['rows_returned']
                     if 'bytes_read' in job_details:
-                        bytes_read = job_details['bytes_read']                    
+                        bytes_read = job_details['bytes_read']
                     resultset_loc = np.NaN
                     if 'resultset_location' in job_details:
-                        resultset_loc = job_details['resultset_location'],
+                        resultset_loc = job_details['resultset_location']
+                    print(resultset_loc)
                     job_list_df = job_list_df.append([{'job_id': job['job_id'],
                                                        'status': job_details['status'],
                                                        'user_id': job_details['user_id'],


### PR DESCRIPTION
The trailing comma returns the resultset location as tuple, which in turn blocks the parquet conversion in the history export