### PR TITLE
improve jobhistory export

### DIFF
--- a/Python/ibmcloudsql/test.py
+++ b/Python/ibmcloudsql/test.py
@@ -214,7 +214,16 @@ result_df = sqlClient.get_result(jobId)
 print(result_df.head(200))
 
 print("Test job history export to COS")
-sqlClient.export_job_history(test_credentials.result_location + "/my_job_history/")
+jobhist_location = test_credentials.result_location + "/my_job_history/"
+sqlClient.export_job_history(jobhist_location,
+    export_file_prefix = "job_export=", export_file_suffix = "/data.parquet")
+
+print("Running query on exported history")
+jobhist_df = sqlClient.run_sql("SELECT * FROM {} STORED AS PARQUET LIMIT 10 INTO {} STORED AS CSV".format(
+    jobhist_location,
+    test_credentials.result_location)
+)
+print(jobhist_df[['job_id','status']])
 
 sqlClient = ibmcloudsql.SQLQuery(test_credentials.apikey, test_credentials.instance_crn, client_info='ibmcloudsql test')
 sqlClient.logon()

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -21,7 +21,7 @@ def readme():
         return f.read()
 
 setup(name='ibmcloudsql',
-      version='0.3.16',
+      version='0.3.17',
       python_requires='>=2.7, <4',
       install_requires=['pandas','requests','ibm-cos-sdk-core','ibm-cos-sdk','numpy',
                         'pyarrow==0.15.1', 'backoff==1.10.0'],


### PR DESCRIPTION
make object name prefix+suffix customizable. allows treating the export date as hive partition
force error+error_message columns to string, even if they are all empty