### PR TITLE
Update ibmcloudsql.rst

### DIFF
--- a/docs/source/ibmcloudsql.rst
+++ b/docs/source/ibmcloudsql.rst
@@ -12,7 +12,7 @@ SQL Query module
    :undoc-members:
    :show-inheritance:
 
-Catalog\Table module
+Catalog/Table module
 ---------------------------------
 
 .. automodule:: ibmcloudsql.catalog_table


### PR DESCRIPTION
If possible, we could get rid of the above level in the toc, called ibmcloudsql, and instead just show ibmcloudsql package. I cannot make this change here.