### PR TITLE
Fixes incorrect job information for queued jobs

### DIFF
--- a/Python/ibmcloudsql/SQLQuery.py
+++ b/Python/ibmcloudsql/SQLQuery.py
@@ -1230,6 +1230,7 @@ class SQLQuery(COSClient, SQLMagic, HiveMetastore):
         if (
             job_id in self.jobs_tracking
             and self.jobs_tracking[job_id].get("status") != "running"
+            and self.jobs_tracking[job_id].get("status") != "queued"
         ):
             result = self.jobs_tracking[job_id]
         else:

--- a/Python/ibmcloudsql/__init__.py
+++ b/Python/ibmcloudsql/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-__version__ = "0.4.19"
+__version__ = "0.4.20"
 # flake8: noqa F401
 from .SQLQuery import SQLQuery
 from .sql_query_ts import SQLClientTimeSeries


### PR DESCRIPTION
If a job has the status `queued` during a `get_job` call, it is added to `self.jobs_tracking` with the status `queued`. If you now call `get_job` again, no new job details are retrieved via the REST API, but only the old job details are returned. This is not a problem for `completed` and `failed` jobs, but it is for `queued` jobs. Therefore, it must be additionally checked that the job status is not `queued`.