### PR TITLE
Adding br-sao COS endpoints

### DIFF
--- a/Python/ibmcloudsql/__init__.py
+++ b/Python/ibmcloudsql/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-__version__ = "0.4.26"
+__version__ = "0.4.27"
 # flake8: noqa F401
 from .SQLQuery import SQLQuery
 from .sql_query_ts import SQLClientTimeSeries

--- a/Python/ibmcloudsql/cos.py
+++ b/Python/ibmcloudsql/cos.py
@@ -219,6 +219,7 @@ class ParsedUrl(object):
             "ca-tor": "s3.ca-tor.cloud-object-storage.appdomain.cloud",
             "jp-tok": "s3.jp-tok.cloud-object-storage.appdomain.cloud",
             "jp-osa": "s3.jp-osa.cloud-object-storage.appdomain.cloud",
+            "br-sao": "s3.br-sao.cloud-object-storage.appdomain.cloud",
             "ap-geo": "s3.ap.cloud-object-storage.appdomain.cloud",
             "ap": "s3.ap.cloud-object-storage.appdomain.cloud",
             "tok-ap-geo": "s3.tok.ap.cloud-object-storage.appdomain.cloud",
@@ -256,6 +257,7 @@ class ParsedUrl(object):
             "s3.ca-tor.cloud-object-storage.appdomain.cloud",
             "s3.jp-tok.cloud-object-storage.appdomain.cloud",
             "s3.jp-osa.cloud-object-storage.appdomain.cloud",
+            "s3.br-sao.cloud-object-storage.appdomain.cloud",
             "s3.us-west.cloud-object-storage.test.appdomain.cloud",
             # cross-region
             "s3.us.cloud-object-storage.appdomain.cloud",


### PR DESCRIPTION
COS endpoint list is missing the `br-sao` endpoint. All available regional endpoints are listed in [Regional Endpoints](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-endpoints).

Signed-off-by: Navid Shakibapour <navid.shakibapour@gmail.com>