### PR TITLE
* update ibm-cos-sdk dependency to 2.10.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     hooks:
     -   id: reorder-python-imports
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: ''  # pick a git hash / tag to point to
+    rev: '3.7.9'  # pick a git hash / tag to point to
     hooks:
     -   id: flake8
 -   repo: https://github.com/ambv/black
@@ -25,3 +25,4 @@ repos:
     rev: v1.2.3
     hooks:
     - id: flake8
+      additional_dependencies: [flake8-docstrings]

--- a/Python/.flake8
+++ b/Python/.flake8
@@ -1,6 +1,0 @@
-[flake8]
-ignore = E203
-per-file-ignores = __init__.py:F401
-
-[pep8]
-ignore = E203

--- a/Python/ibmcloudsql/SQLQuery.py
+++ b/Python/ibmcloudsql/SQLQuery.py
@@ -56,12 +56,12 @@ except Exception:
 try:
     from .cos import COSClient
     from .utilities import rename_keys
-    from .sql_magic import SQLMagic, format_sql, print_sql
+    from .sql_magic import SQLBuilder, format_sql, print_sql
     from .catalog_table import HiveMetastore
 except ImportError:
     from cos import COSClient
     from utilities import rename_keys
-    from sql_magic import SQLMagic, format_sql, print_sql
+    from sql_magic import SQLBuilder, format_sql, print_sql
     from catalog_table import HiveMetastore
 import logging
 from functools import wraps
@@ -69,6 +69,9 @@ import json
 from json import JSONDecodeError
 import inspect
 import re
+from datetime import datetime
+from threading import Thread
+from timeit import default_timer as timer
 
 logger = logging.getLogger(__name__)
 
@@ -92,9 +95,70 @@ def validate_job_status(f):
     return wrapped
 
 
+saved_jobs_prev_time = datetime.now()
+
+
+def save(file_name, data):
+    """Save file still ok in the case of Ctrl-C is pressed"""
+    # backup file regularly
+    import time
+    from dateutil.relativedelta import relativedelta
+
+    global saved_jobs_prev_time
+    now = datetime.now()
+    diff = relativedelta(now, saved_jobs_prev_time)
+    backup_file = None
+    if diff.hours > 1:
+        saved_jobs_prev_time = now
+        t = time.localtime()
+        timestamp = time.strftime("%b-%d-%Y_%H%M", t)
+        backup_file = "{}-{}".format(file_name, timestamp)
+
+    a = Thread(target=_save_no_interrupt, args=(file_name, data, backup_file))
+    a.start()
+    a.join()
+
+
+def _save_no_interrupt(file_name, data, backup_file):
+    if backup_file is not None:
+        import shutil
+
+        shutil.copyfile(file_name, backup_file)
+    with open(file_name, "w") as outfile:
+        json.dump(data, outfile)
+
+
 def check_saved_jobs_decorator(f):
     """a decorator that load data from ProjectLib, check for completed SQL
     Query job, before deciding to launch it"""
+
+    def check_rerun_failed_job(self, job_result, sql_stmt, prefix):
+        """for failed job due to long runtime: raise SqlQueryTimeOutException
+        so that the caller knows to split the job into two smaller jobs"""
+        run_as_usual = False
+        if job_result["status"] == "failed":
+            if (
+                "error_message" in job_result
+                and "location does not exist" in job_result["error_message"]
+            ):
+                print("skip due to no data: {}".format(sql_stmt))
+            else:
+                # if failed because of too-long, don't try it again
+                from dateutil import parser
+
+                startt = parser.parse(job_result["submit_time"])
+                endt = parser.parse(job_result["end_time"])
+                tMin = (endt - startt).seconds / 60
+                if tMin > 50:
+                    self._data[sql_stmt]["lower_granularity"] = True
+                    self._data[sql_stmt]["run_time_more_than"] = tMin
+                    save(prefix, self._data)
+                    msg = "Runtime: {} (min). Need to change the SQL statement to reduce running time".format(
+                        tMin
+                    )
+                    raise SqlQueryTimeOutException(msg)
+                run_as_usual = True
+        return run_as_usual
 
     @wraps(f)
     def wrapped(*args, **kwargs):
@@ -102,6 +166,7 @@ def check_saved_jobs_decorator(f):
         dictionary = inspect.getcallargs(f, *args, **kwargs)
         prefix = dictionary["file_name"]  # Gets you the username, default or modifed
         sql_stmt = dictionary["sql_stmt"]
+        force_rerun = dictionary["force_rerun"]
         # refine query
         sql_stmt = format_sql(sql_stmt)
 
@@ -121,7 +186,9 @@ def check_saved_jobs_decorator(f):
                 if len(keys_mapping) > 0:
                     rename_keys(self.project_lib.data, keys_mapping)
 
-            if sql_stmt in self.project_lib.data:
+            if force_rerun is True:
+                run_as_usual = True
+            elif sql_stmt in self.project_lib.data:
                 run_as_usual = False
                 job_id = self.project_lib.data[sql_stmt]["job_id"]
                 if self.project_lib.data[sql_stmt]["status"] == "completed":
@@ -130,6 +197,7 @@ def check_saved_jobs_decorator(f):
                     if self.project_lib.data[sql_stmt]["status"] != status_no_job_id:
                         # query the status
                         job_result = self.get_job(job_id)
+                        job_result.pop("statement", None)
                         self.project_lib.data[sql_stmt]["job_info"] = job_result
                         try:
                             self.project_lib.data[sql_stmt]["status"] = job_result[
@@ -140,8 +208,9 @@ def check_saved_jobs_decorator(f):
 
                             pprint.pprint(job_id, "\n", job_result)
                             raise e
-                        if job_result["status"] == "failed":
-                            run_as_usual = True
+                        run_as_usual = check_rerun_failed_job(
+                            self, job_result, sql_stmt, prefix
+                        )
                         self.write_project_lib_data()
                     else:
                         run_as_usual = True
@@ -155,8 +224,18 @@ def check_saved_jobs_decorator(f):
                     prefix = self._tracking_filename
             try:
                 with open(prefix) as json_data:
-                    self._data = json.load(json_data)
-                if sql_stmt in self._data:
+                    try:
+                        self._data = json.load(json_data)
+                    except ValueError:
+                        print(
+                            "Can't load {prefix} file: not a valid JSON file".format(
+                                prefix=prefix
+                            )
+                        )
+                        assert 0
+                if force_rerun is True:
+                    run_as_usual = True
+                elif sql_stmt in self._data:
                     run_as_usual = False
                     job_id = self._data[sql_stmt]["job_id"]
                     if self._data[sql_stmt]["status"] == "completed":
@@ -165,6 +244,7 @@ def check_saved_jobs_decorator(f):
                         if self._data[sql_stmt]["status"] != status_no_job_id:
                             # query the status
                             job_result = self.get_job(job_id)
+                            job_result.pop("statement", None)
                             self._data[sql_stmt]["job_info"] = job_result
                             try:
                                 self._data[sql_stmt]["status"] = job_result["status"]
@@ -173,10 +253,10 @@ def check_saved_jobs_decorator(f):
 
                                 pprint.pprint(job_result)
                                 raise e
-                            if job_result["status"] == "failed":
-                                run_as_usual = True
-                            with open(prefix, "w") as outfile:
-                                json.dump(self._data, outfile)
+                            run_as_usual = check_rerun_failed_job(
+                                self, job_result, sql_stmt, prefix
+                            )
+                            save(prefix, self._data)
                         else:
                             run_as_usual = True
             except FileNotFoundError:
@@ -195,8 +275,7 @@ def check_saved_jobs_decorator(f):
                 else:
                     # use local file
                     self._data[sql_stmt] = result
-                    with open(prefix, "w") as outfile:
-                        json.dump(self._data, outfile)
+                    save(prefix, self._data)
             except Exception as e:
                 e_ = e
                 status = status_no_job_id
@@ -211,8 +290,7 @@ def check_saved_jobs_decorator(f):
                 else:
                     # use local file
                     self._data[sql_stmt] = {"job_id": job_id, "status": status}
-                    with open(prefix, "w") as outfile:
-                        json.dump(self._data, outfile)
+                    save(prefix, self._data)
             if e_ is not None:
                 raise e_
         return job_id
@@ -220,7 +298,7 @@ def check_saved_jobs_decorator(f):
     return wrapped
 
 
-class SQLQuery(COSClient, SQLMagic, HiveMetastore):
+class SQLQuery(COSClient, SQLBuilder, HiveMetastore):
     """The class the provides necessary APIs to interact with
 
     1. IBM SQL Serverless service
@@ -273,7 +351,7 @@ class SQLQuery(COSClient, SQLMagic, HiveMetastore):
             thread_safe=thread_safe,
             staging=staging_env,
         )
-        SQLMagic.__init__(self)
+        SQLBuilder.__init__(self)
         if target_cos_url is not None:
             HiveMetastore.__init__(self, target_cos_url)
 
@@ -281,6 +359,7 @@ class SQLQuery(COSClient, SQLMagic, HiveMetastore):
         self.target_cos_url = target_cos_url
         self.export_cos_url = target_cos_url
         self.user_agent = client_info
+        self._supported_format_types = ["JSON", "CSV", "PARQUET"]
 
         self.max_tries = max_tries
         self.max_concurrent_jobs = (
@@ -290,8 +369,13 @@ class SQLQuery(COSClient, SQLMagic, HiveMetastore):
         # track the status of jobs - save the time to SQLQuery server
         self.jobs_tracking = {}
         self._tracking_filename = None
+        self._supported_job_status = ["running", "completed", "failed", "unknown"]
 
         logger.debug("SQLClient created successful")
+
+    def is_a_supported_storage_type(self, typ):
+        """check if a type is in a supported format"""
+        return typ.upper() in self._supported_format_types
 
     def set_tracking_file(self, file_name):
         """provides the file name which is used for tracking multiple SQL requests
@@ -424,12 +508,12 @@ class SQLQuery(COSClient, SQLMagic, HiveMetastore):
                 raise SyntaxError(error_message)
 
     def submit(self, pagesize=None):
-        """ run the internal SQL statement that you created using the APIs provided by SQLMagic
+        """ run the internal SQL statement that you created using the APIs provided by SQLBuilder
         """
         self.format_()
         return self.submit_sql(self._sql_stmt, pagesize=pagesize)
 
-    def submit_sql(self, sql_stmt, pagesize=None):
+    def submit_sql(self, sql_stmt, pagesize=None, stored_as=None):
         """
         Asynchronous call - submit and quickly return the job_id.
 
@@ -440,6 +524,8 @@ class SQLQuery(COSClient, SQLMagic, HiveMetastore):
         pagesize: int, optional
             an integer indicating the number of rows for each partition/page
             [using PARTITIONED EVERY <pagesize> ROWS syntax]
+        stored_as: string
+            The type being used, only if 'INTO ... STORED AS ...' is not provided
 
         Returns
         -------
@@ -528,7 +614,13 @@ class SQLQuery(COSClient, SQLMagic, HiveMetastore):
         if pagesize or pagesize == 0:
             if type(pagesize) == int and pagesize > 0:
                 if self.target_cos_url and not INTO_is_present(sql_text):
-                    sqlData["statement"] += " INTO {}".format(self.target_cos_url)
+                    if stored_as is not None:
+                        assert self.is_a_supported_storage_type(stored_as)
+                        sqlData["statement"] += " INTO {} STORED AS {format}".format(
+                            self.target_cos_url, format=stored_as
+                        )
+                    else:
+                        sqlData["statement"] += " INTO {}".format(self.target_cos_url)
                 elif not INTO_is_present(sql_text):
                     raise SyntaxError(
                         'Neither resultset_target parameter nor "INTO" clause specified.'
@@ -543,7 +635,13 @@ class SQLQuery(COSClient, SQLMagic, HiveMetastore):
                     "pagesize parameter ({}) is not valid.".format(pagesize)
                 )
         elif self.target_cos_url and not INTO_is_present(sql_text):
-            sqlData.update({"resultset_target": self.target_cos_url})
+            if stored_as is not None:
+                assert self.is_a_supported_storage_type(stored_as)
+                sqlData["statement"] += " INTO {} STORED AS {format}".format(
+                    self.target_cos_url, format=stored_as
+                )
+            else:
+                sqlData.update({"resultset_target": self.target_cos_url})
 
         max_tries = self.max_tries
         intrumented_send = backoff.on_exception(
@@ -554,7 +652,9 @@ class SQLQuery(COSClient, SQLMagic, HiveMetastore):
         return intrumented_send(sqlData)
 
     @check_saved_jobs_decorator
-    def submit_and_track_sql(self, sql_stmt, pagesize=None, file_name=None):
+    def submit_and_track_sql(
+        self, sql_stmt, pagesize=None, file_name=None, force_rerun=False, stored_as=None
+    ):
         """
         Each SQL Query instance is limited by the number of sql queries that it
         can handle at a time.  This can be a problem when you
@@ -601,6 +701,10 @@ class SQLQuery(COSClient, SQLMagic, HiveMetastore):
             * (2) you use local notebook, and you want to use a local file to track it
 
             You don't need to provide the file name if you're using Watson studio, and the file name has been provided via :meth:`.connect_project_lib`.
+        force_rerun: bool
+            Rerun even if the given sql statement has been previously launched and completed. Be cautious when enabling this flag, as
+            you may have duplicated number of data onto the same location. The reason for this flag is to provide the option to rerun a command
+            - in that the previously created data has been deleted.
 
         Notes
         -----
@@ -609,7 +713,7 @@ class SQLQuery(COSClient, SQLMagic, HiveMetastore):
             This APIs make use of :py:meth:`.COSClient.connect_project_lib`, :py:meth:`.COSClient.read_project_lib_data`.
 
         """
-        return self.submit_sql(sql_stmt, pagesize=pagesize)
+        return self.submit_sql(sql_stmt, pagesize=pagesize, stored_as=stored_as)
 
     def wait_for_job(self, jobId, sleep_time=2):
         """
@@ -1423,7 +1527,7 @@ class SQLQuery(COSClient, SQLMagic, HiveMetastore):
         """ return the number of running jobs in the SQL Query server"""
         return self.get_jobs_count_with_status("running")
 
-    def execute_sql(self, sql_stmt, pagesize=None, get_result=False):
+    def execute_sql(self, sql_stmt, pagesize=None, get_result=False, stored_as=None):
         """
         Extend the behavior of :meth:`.run_sql`.
         It is a blocking call that waits for the job to finish (unlike :meth:`.submit_sql`), but it has the following features:
@@ -1461,7 +1565,7 @@ class SQLQuery(COSClient, SQLMagic, HiveMetastore):
         """
         Container = namedtuple("RunSql", ["data", "job_id"])
 
-        job_id = self.submit_sql(sql_stmt, pagesize=pagesize)
+        job_id = self.submit_sql(sql_stmt, pagesize=pagesize, stored_as=stored_as)
         data = None
         job_status = self.wait_for_job(job_id)
         logger.debug("Job " + job_id + " terminated with status: " + job_status)
@@ -1552,7 +1656,7 @@ class SQLQuery(COSClient, SQLMagic, HiveMetastore):
         return self.get_result(job_id)
 
     def run(self, pagesize=None, get_result=False):
-        """ run the internal SQL statement provided by SQLMagic using :meth:`.execute_sql`
+        """ run the internal SQL statement provided by SQLBuilder using :meth:`.execute_sql`
         """
         self.format_()
         return self.execute_sql(
@@ -1704,7 +1808,7 @@ class SQLQuery(COSClient, SQLMagic, HiveMetastore):
         else:
             print("No new jobs to export")
 
-    def get_schema_data(self, cos_url, type="json", dry_run=False):
+    def get_schema_data(self, cos_url, typ="json", dry_run=False):
         """
         Return the schema of COS URL
 
@@ -1712,11 +1816,14 @@ class SQLQuery(COSClient, SQLMagic, HiveMetastore):
         ----------
         cos_url : str
             The COS URL where data is stored
-        type : str, optional
+        typ : str, optional
             The format type of the data, default is 'json'
             Use from ['json', 'csv', 'parquet'] with case-insensitive
         dry_run: bool, optional
             This option, once selected as True, returns the internally generated SQL statement, and no job is queried.
+        result_format: string
+            'dataframe'
+            'list'
 
         Returns
         -------
@@ -1729,22 +1836,27 @@ class SQLQuery(COSClient, SQLMagic, HiveMetastore):
             in either scenarios: (1) target COS URL is not set, (2) invalid type, (3) invalid COS URL
 
         """
-        supported_types = ["JSON", "CSV", "PARQUET"]
+        if not self.is_a_supported_storage_type(typ):
+            logger.error("use wrong format")
+            msg = """
+"Use wrong format of data: 'typ' option")
+Acceptable values: {}
+            """.format(
+                str(self._supported_format_types)
+            )
+            raise ValueError(msg)
 
         if self.target_cos_url is None:
             msg = "Need to pass target COS URL when creating SQL Client object"
-            raise ValueError(msg)
-        if type.upper() not in supported_types:
-            msg = "Expected 'type' value: " + str(supported_types)
             raise ValueError(msg)
         if not self.is_valid_cos_url(cos_url):
             msg = "Not a valid COS URL"
             raise ValueError(msg)
         sql_stmt = """
-        SELECT * FROM DESCRIBE({cos_in} STORED AS {type})
+        SELECT * FROM DESCRIBE({cos_in} STORED AS {typ})
         INTO {cos_out} STORED AS JSON
         """.format(
-            cos_in=cos_url, type=type.upper(), cos_out=self.target_cos_url
+            cos_in=cos_url, typ=typ.upper(), cos_out=self.target_cos_url
         )
         if dry_run:
             print(sql_stmt)
@@ -1755,7 +1867,7 @@ class SQLQuery(COSClient, SQLMagic, HiveMetastore):
                 "�]�]L�" in df.name[0] and "PAR1" in df.name[0]
             ):
                 msg = (
-                    "ERROR: Revise 'type' value, underlying data format maybe different"
+                    "ERROR: Revise 'typ' value, underlying data format maybe different"
                 )
                 raise ValueError(msg)
             return df

--- a/Python/ibmcloudsql/__init__.py
+++ b/Python/ibmcloudsql/__init__.py
@@ -19,4 +19,4 @@ __version__ = "0.4.24"
 from .SQLQuery import SQLQuery
 from .sql_query_ts import SQLClientTimeSeries
 from .exceptions import RateLimitedException
-from .sql_magic import SQLMagic
+from .sql_magic import SQLBuilder

--- a/Python/ibmcloudsql/cos.py
+++ b/Python/ibmcloudsql/cos.py
@@ -18,7 +18,8 @@ import getpass
 import time
 import xml.etree.ElementTree as ET
 from collections import namedtuple
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
 from pprint import pformat
 
 import ibm_boto3
@@ -501,9 +502,9 @@ class COSClient(ParsedUrl, IBMCloudAccess):
         source_url_parsed = self.analyze_cos_url(source_cos_url)
         target_cos_url = self.get_exact_url(target_cos_url)
         target_url_parsed = self.analyze_cos_url(target_cos_url)
-        target_prefix=target_url_parsed.prefix
+        target_prefix = target_url_parsed.prefix
         if len(target_prefix) > 0:
-            if target_prefix[-1] != '/':
+            if target_prefix[-1] != "/":
                 target_prefix = target_prefix + "/"
         cos_client = self._get_cos_client(target_url_parsed.endpoint)
 
@@ -512,24 +513,51 @@ class COSClient(ParsedUrl, IBMCloudAccess):
         start_date = source_objects.LastModified.min()
         end_date = source_objects.LastModified.max()
         for n in range(int((end_date - start_date).days) + 1):
-            current_date = start_date + timedelta(n-1)
-            current_objects = source_objects[(source_objects['LastModified'] >= current_date - timedelta(days=buffer_days)) &
-                                             (source_objects['LastModified'] <= current_date + timedelta(days=buffer_days))]
+            current_date = start_date + timedelta(n - 1)
+            current_objects = source_objects[
+                (
+                    source_objects["LastModified"]
+                    >= current_date - timedelta(days=buffer_days)
+                )
+                & (
+                    source_objects["LastModified"]
+                    <= current_date + timedelta(days=buffer_days)
+                )
+            ]
 
             for source_index, source_object in current_objects.iterrows():
-                current_source = source_url_parsed.bucket + "/" + source_object['Object']
-                if "/_schema_as_json" in current_source or "/_checkpoint/" in current_source:
-                    continue # Don't copy SQL Query stream data landing checkpoint and schema objects.
-                current_target_object = source_object['Object'][len(source_url_parsed.prefix):]
-                current_target_prefix = "{}_date_landed={}".format(target_prefix, current_date)
+                current_source = (
+                    source_url_parsed.bucket + "/" + source_object["Object"]
+                )
+                if (
+                    "/_schema_as_json" in current_source
+                    or "/_checkpoint/" in current_source
+                ):
+                    continue  # Don't copy SQL Query stream data landing checkpoint and schema objects.
+                current_target_object = source_object["Object"][
+                    len(source_url_parsed.prefix) :
+                ]
+                current_target_prefix = "{}_date_landed={}".format(
+                    target_prefix, current_date
+                )
                 cos_client.copy_object(
                     Bucket=target_url_parsed.bucket,
                     CopySource=current_source,
-                    Key=current_target_prefix + "/" + current_target_object
+                    Key=current_target_prefix + "/" + current_target_object,
                 )
-            if len(current_objects)>0:
-                cos_client.put_object(Body='', Bucket=target_url_parsed.bucket, Key=current_target_prefix + "/_SUCCESS")
-                print("Copied {} objects to bucket {} into folder {}.".format(len(current_objects), target_url_parsed.bucket, current_target_prefix))
+            if len(current_objects) > 0:
+                cos_client.put_object(
+                    Body="",
+                    Bucket=target_url_parsed.bucket,
+                    Key=current_target_prefix + "/_SUCCESS",
+                )
+                print(
+                    "Copied {} objects to bucket {} into folder {}.".format(
+                        len(current_objects),
+                        target_url_parsed.bucket,
+                        current_target_prefix,
+                    )
+                )
 
     def list_cos_objects(self, cos_url, size_unit=None, sort_by_size=False):
         """
@@ -603,10 +631,11 @@ class COSClient(ParsedUrl, IBMCloudAccess):
             }
             assert size_unit in ["B", "KB", "MB", "GB"]
             result.Size = result.Size / mapping[size_unit]
-        else:
-            result = pd.DataFrame()
         if sort_by_size is True:
-            result.sort_values("Size", inplace=True, ascending=False)
+            if result is not None:
+                result.sort_values("Size", inplace=True, ascending=False)
+            else:
+                result = pd.DataFrame()
         return result
 
     def delete_empty_objects(self, cos_url):
@@ -1053,6 +1082,29 @@ class COSClient(ParsedUrl, IBMCloudAccess):
             "largest_object_size": sizeof_fmt(largest_size),
             "largest_object": largest_object,
         }
+
+    def copy_objects(self, source_path, cos_url):
+        """
+        Upload a file to a given COS URL
+
+        Raises
+        -------
+        ValueError
+            if COS URL is invalid
+        """
+        if not self.is_valid_cos_url(cos_url):
+            msg = "Not a valid COS URL: {}".format(cos_url)
+            raise ValueError(msg)
+        # result_objects = self.list_cos_objects(cos_url)
+        url_parsed = self.analyze_cos_url(cos_url)
+        cos_client = self._get_cos_client(url_parsed.endpoint)
+        bucket = url_parsed.bucket
+        try:
+            res = cos_client.upload_file(source_path, cos_url)
+        except Exception as e:
+            print(Exception, e)
+        else:
+            print("File uploaded")
 
     # -----------------
     # The methods below are for interacting with a file stored as an asset in a Watson Studio's Project.

--- a/Python/ibmcloudsql/test.py
+++ b/Python/ibmcloudsql/test.py
@@ -1,34 +1,62 @@
+"""
+This is the test script
+"""
+# flake8: noqa W191
 import sys
-sys.path.append('ibmcloudsql')
-import ibmcloudsql
+
+import pandas as pd
+
+sys.path.append("ibmcloudsql")
+import ibmcloudsql  # noqa
+import test_credentials  # noqa
+
 try:
     from exceptions import RateLimitedException
 except Exception:
     from .exceptions import RateLimitedException
 
-import test_credentials
-import pandas as pd
-pd.set_option('display.max_colwidth', None)
-pd.set_option('display.max_columns', 20)
+pd.set_option("display.max_colwidth", None)
+pd.set_option("display.max_columns", 20)
 
 if test_credentials.result_location[-1] != "/":
     test_credentials.result_location += "/"
 
-sqlClient = ibmcloudsql.SQLQuery(test_credentials.apikey, test_credentials.instance_crn, client_info='ibmcloudsql test') # maintain backward compatible
+sqlClient = ibmcloudsql.SQLQuery(
+    test_credentials.apikey,
+    test_credentials.instance_crn,
+    client_info="ibmcloudsql test",
+)  # maintain backward compatible
 
-sqlClient = ibmcloudsql.SQLQuery(test_credentials.apikey, test_credentials.instance_crn, target_cos_url=test_credentials.result_location, client_info='ibmcloudsql test')
+sqlClient = ibmcloudsql.SQLQuery(
+    test_credentials.apikey,
+    test_credentials.instance_crn,
+    target_cos_url=test_credentials.result_location,
+    client_info="ibmcloudsql test",
+)
 sqlClient.logon()
 sqlClient.sql_ui_link()
 
 print("Running test with individual method invocation and Parquet target:")
-jobId = sqlClient.submit_sql("SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS PARQUET".format(test_credentials.result_location))
+jobId = sqlClient.submit_sql(
+    "SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS PARQUET".format(
+        test_credentials.result_location
+    )
+)
 sqlClient.wait_for_job(jobId)
 result_df = sqlClient.get_result(jobId)
-print("jobId {} restults are stored in {}. Result set is:".format(jobId, sqlClient.get_job(jobId)['resultset_location']))
+print(
+    "jobId {} restults are stored in {}. Result set is:".format(
+        jobId, sqlClient.get_job(jobId)["resultset_location"]
+    )
+)
 print(result_df.head(200))
 
 print("Running test with individual method invocation and ORC target:")
-jobId = sqlClient.submit_sql("SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS ORC".format(test_credentials.result_location))
+jobId = sqlClient.submit_sql(
+    "SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS ORC".format(
+        test_credentials.result_location
+    )
+)
 sqlClient.wait_for_job(jobId)
 try:
     result_df = sqlClient.get_result(jobId)
@@ -36,15 +64,23 @@ except ValueError as e:
     print(e)
 
 print("Running test with individual method invocation and CSV target:")
-jobId = sqlClient.submit_sql("SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS CSV".format(test_credentials.result_location))
+jobId = sqlClient.submit_sql(
+    "SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS CSV".format(
+        test_credentials.result_location
+    )
+)
 sqlClient.wait_for_job(jobId)
 result_df = sqlClient.get_result(jobId)
-print("jobId {} restults are stored in {}. Result set is:".format(jobId, sqlClient.get_job(jobId)['resultset_location']))
+print(
+    "jobId {} restults are stored in {}. Result set is:".format(
+        jobId, sqlClient.get_job(jobId)["resultset_location"]
+    )
+)
 print(result_df.head(200))
 
 print("Running test with individual method invocation and JSON target:")
 jobId = sqlClient.submit_sql(
-        "WITH orders as (SELECT customerid, named_struct('count', count(orderid), 'orderids', collect_list(orderid)) orders \
+    "WITH orders as (SELECT customerid, named_struct('count', count(orderid), 'orderids', collect_list(orderid)) orders \
                 FROM cos://us-geo/sql/orders.parquet STORED AS PARQUET  \
                 GROUP BY customerid)    \
         SELECT c.customerid,    \
@@ -54,10 +90,17 @@ jobId = sqlClient.submit_sql(
         FROM cos://us-geo/sql/customers.parquet STORED AS PARQUET c,    \
              orders o   \
         WHERE o.customerid=c.customerid \
-        INTO {} STORED AS JSON".format(test_credentials.result_location))
+        INTO {} STORED AS JSON".format(
+        test_credentials.result_location
+    )
+)
 sqlClient.wait_for_job(jobId)
 result_df = sqlClient.get_result(jobId)
-print("jobId {} restults are stored in {}. Result set is:".format(jobId, sqlClient.get_job(jobId)['resultset_location']))
+print(
+    "jobId {} restults are stored in {}. Result set is:".format(
+        jobId, sqlClient.get_job(jobId)["resultset_location"]
+    )
+)
 print(result_df.head(10))
 
 print("Running test rate limiting without retry. Expecting RateLimitedException:")
@@ -69,7 +112,9 @@ sql = "WITH prefiltered_hospitals AS ( \
         GROUP BY c.name, c.shape_WKT, h.name) \
      SELECT county, hospital FROM prefiltered_hospitals \
      WHERE ST_Intersects(ST_WKTToSQL(hospital_location), ST_WKTToSQL(county_location)) \
-     INTO {} STORED AS CSV".format(test_credentials.result_location)
+     INTO {} STORED AS CSV".format(
+    test_credentials.result_location
+)
 jobidArray = []
 try:
     for x in range(test_credentials.instance_rate_limit + 1):
@@ -81,7 +126,13 @@ for jobId in jobidArray:
     sqlClient.wait_for_job(jobId)
 
 print("Running test rate limiting with retry:")
-sqlClientRetry = ibmcloudsql.SQLQuery(test_credentials.apikey, test_credentials.instance_crn, target_cos_url=test_credentials.result_location, client_info='ibmcloudsql test', max_tries = 5)
+sqlClientRetry = ibmcloudsql.SQLQuery(
+    test_credentials.apikey,
+    test_credentials.instance_crn,
+    target_cos_url=test_credentials.result_location,
+    client_info="ibmcloudsql test",
+    max_tries=5,
+)
 sqlClientRetry.logon()
 jobidArray = []
 for x in range(test_credentials.instance_rate_limit + 1):
@@ -91,12 +142,20 @@ for jobId in jobidArray:
     sqlClientRetry.wait_for_job(jobId)
 
 print("Running test with partitioned CSV target:")
-jobId = sqlClient.submit_sql("SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET INTO {} STORED AS CSV PARTITIONED BY (city)".format(test_credentials.result_location))
+jobId = sqlClient.submit_sql(
+    "SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET INTO {} STORED AS CSV PARTITIONED BY (city)".format(
+        test_credentials.result_location
+    )
+)
 sqlClient.wait_for_job(jobId)
 result_objects_df = sqlClient.list_results(jobId)
 print(result_objects_df.head(200))
 result_df = sqlClient.get_result(jobId)
-print("jobId {} results are stored in {}. Result set is:".format(jobId, sqlClient.get_job(jobId)['resultset_location']))
+print(
+    "jobId {} results are stored in {}. Result set is:".format(
+        jobId, sqlClient.get_job(jobId)["resultset_location"]
+    )
+)
 print(result_df.head(200))
 
 print("Expecting failure when trying to rename partitioned results to exact target:")
@@ -107,7 +166,11 @@ except ValueError as e:
 print("Running test with exact target object name creation:")
 cos_url = "{}myresult.parquet".format(test_credentials.result_location)
 sqlClient.delete_objects(cos_url)
-jobId = sqlClient.submit_sql("SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} JOBPREFIX NONE STORED AS PARQUET".format(cos_url))
+jobId = sqlClient.submit_sql(
+    "SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} JOBPREFIX NONE STORED AS PARQUET".format(
+        cos_url
+    )
+)
 sqlClient.wait_for_job(jobId)
 result_df = sqlClient.get_result(jobId)
 sqlClient.rename_exact_result(jobId)
@@ -124,7 +187,12 @@ res = sqlClient.delete_result(jobId)
 print(res)
 
 print("Running test with paginated parquet target:")
-jobId = sqlClient.submit_sql("SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS PARQUET".format(test_credentials.result_location), 2)
+jobId = sqlClient.submit_sql(
+    "SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS PARQUET".format(
+        test_credentials.result_location
+    ),
+    2,
+)
 sqlClient.wait_for_job(jobId)
 result_df = sqlClient.get_result(jobId, 1)
 print("jobId {} result page 1 is:".format(jobId))
@@ -144,24 +212,34 @@ except ValueError as e:
     print(e)
 print("Trying to use wrong data type for page number:")
 try:
-    result_df = sqlClient.get_result(jobId, 'abc')
+    result_df = sqlClient.get_result(jobId, "abc")
 except ValueError as e:
     print(e)
 print("Trying to run SQL with invalid pagesize:")
 try:
-    jobId = sqlClient.submit_sql("SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS PARQUET".format(test_credentials.result_location), 0)
+    jobId = sqlClient.submit_sql(
+        "SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS PARQUET".format(
+            test_credentials.result_location
+        ),
+        0,
+    )
 except ValueError as e:
     print(e)
 print("Trying to run SQL with PARTITIONED clause plus pagesize:")
 try:
-    jobId = sqlClient.submit_sql("SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS PARQUET PARTITIONED BY (city)".format(test_credentials.result_location), 2)
+    jobId = sqlClient.submit_sql(
+        "SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS PARQUET PARTITIONED BY (city)".format(
+            test_credentials.result_location
+        ),
+        2,
+    )
 except SyntaxError as e:
     print(e)
 
 
 print("Running test with paginated JSON target:")
 jobId = sqlClient.submit_sql(
-        "WITH orders as (SELECT customerid, named_struct('count', count(orderid), 'orderids', collect_list(orderid)) orders \
+    "WITH orders as (SELECT customerid, named_struct('count', count(orderid), 'orderids', collect_list(orderid)) orders \
                 FROM cos://us-geo/sql/orders.parquet STORED AS PARQUET  \
                 GROUP BY customerid)    \
         SELECT c.customerid,    \
@@ -171,7 +249,11 @@ jobId = sqlClient.submit_sql(
         FROM cos://us-geo/sql/customers.parquet STORED AS PARQUET c,    \
              orders o   \
         WHERE o.customerid=c.customerid \
-        INTO {} STORED AS JSON".format(test_credentials.result_location), pagesize=10)
+        INTO {} STORED AS JSON".format(
+        test_credentials.result_location
+    ),
+    pagesize=10,
+)
 sqlClient.wait_for_job(jobId)
 result_df_list = sqlClient.list_results(jobId)
 print("jobId {} result pages:".format(jobId))
@@ -183,7 +265,7 @@ print(result_df.head(10))
 
 print("Running test with compound method invocation:")
 result_df = sqlClient.run_sql(
-"WITH orders_shipped AS \
+    "WITH orders_shipped AS \
   (SELECT OrderID, EmployeeID, (CASE WHEN shippedDate < requiredDate \
                                    THEN 'On Time' \
                                    ELSE 'Late' \
@@ -195,19 +277,34 @@ FROM orders_shipped o, \
 WHERE e.EmployeeID = o.EmployeeID \
 GROUP BY e.FirstName, e.LastName, Shipped \
 ORDER BY e.LastName, e.FirstName, NumOrders DESC \
-INTO {} STORED AS CSV".format(test_credentials.result_location))
+INTO {} STORED AS CSV".format(
+        test_credentials.result_location
+    )
+)
 print("Result set is:")
 print(result_df.head(200))
 
 print("Running test with SQL grammar error:")
 try:
-    print(sqlClient.run_sql("SELECT xyzFROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS CSV".format(test_credentials.result_location)))
+    print(
+        sqlClient.run_sql(
+            "SELECT xyzFROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS CSV".format(
+                test_credentials.result_location
+            )
+        )
+    )
 except Exception as e:
     print(e)
 
 print("Running test with SQL runtime error:")
 try:
-    print(sqlClient.run_sql("SELECT xyz FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS CSV".format(test_credentials.result_location)))
+    print(
+        sqlClient.run_sql(
+            "SELECT xyz FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS CSV".format(
+                test_credentials.result_location
+            )
+        )
+    )
 except Exception as e:
     print(e)
 
@@ -215,9 +312,9 @@ print("SQL UI Link:")
 sqlClient.sql_ui_link()
 
 print("Job list:")
-pd.set_option('display.max_colwidth', 10)
+pd.set_option("display.max_colwidth", 10)
 print(sqlClient.get_jobs().head(200))
-pd.set_option('display.max_colwidth', None)
+pd.set_option("display.max_colwidth", None)
 
 print("COS Summary:")
 print(sqlClient.get_cos_summary(test_credentials.result_location))
@@ -227,9 +324,16 @@ objects_df = sqlClient.list_cos_objects(test_credentials.result_location)
 print(objects_df.head(100))
 
 print("Test with target URL as separate parameter")
-sqlClient = ibmcloudsql.SQLQuery(test_credentials.apikey, test_credentials.instance_crn, target_cos_url=test_credentials.result_location, client_info='ibmcloudsql test')
+sqlClient = ibmcloudsql.SQLQuery(
+    test_credentials.apikey,
+    test_credentials.instance_crn,
+    target_cos_url=test_credentials.result_location,
+    client_info="ibmcloudsql test",
+)
 sqlClient.logon()
-jobId = sqlClient.submit_sql("SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10")
+jobId = sqlClient.submit_sql(
+    "SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10"
+)
 sqlClient.wait_for_job(jobId)
 result_objects_df = sqlClient.list_results(jobId)
 print(result_objects_df.head(200))
@@ -238,27 +342,49 @@ print(result_df.head(200))
 
 print("Test job history export to COS")
 jobhist_location = test_credentials.result_location + "my_job_history/"
-sqlClient.export_job_history(jobhist_location,
-    export_file_prefix = "job_export=", export_file_suffix = "/data.parquet")
+sqlClient.export_job_history(
+    jobhist_location,
+    export_file_prefix="job_export=",
+    export_file_suffix="/data.parquet",
+)
 
-sqlClient = ibmcloudsql.SQLQuery(test_credentials.apikey, test_credentials.instance_crn, target_cos_url=test_credentials.result_location, client_info='ibmcloudsql test')
+sqlClient = ibmcloudsql.SQLQuery(
+    test_credentials.apikey,
+    test_credentials.instance_crn,
+    target_cos_url=test_credentials.result_location,
+    client_info="ibmcloudsql test",
+)
 sqlClient.logon()
 
 print("Running query on exported history")
-jobhist_df = sqlClient.run_sql("SELECT * FROM {} STORED AS PARQUET LIMIT 10 INTO {} STORED AS CSV".format(
-    jobhist_location,
-    test_credentials.result_location)
+jobhist_df = sqlClient.run_sql(
+    "SELECT * FROM {} STORED AS PARQUET LIMIT 10 INTO {} STORED AS CSV".format(
+        jobhist_location, test_credentials.result_location
+    )
 )
-print(jobhist_df[['job_id','status']])
+print(jobhist_df[["job_id", "status"]])
 
 print("Running EU test with individual method invocation and Parquet target:")
 try:
-    sqlClient_eu = ibmcloudsql.SQLQuery(test_credentials.apikey, test_credentials.eu_instance_crn, target_cos_url=test_credentials.result_location, client_info='ibmcloudsql test')
+    sqlClient_eu = ibmcloudsql.SQLQuery(
+        test_credentials.apikey,
+        test_credentials.eu_instance_crn,
+        target_cos_url=test_credentials.result_location,
+        client_info="ibmcloudsql test",
+    )
     sqlClient_eu.logon()
-    jobId = sqlClient_eu.submit_sql("SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS PARQUET".format(test_credentials.eu_result_location))
+    jobId = sqlClient_eu.submit_sql(
+        "SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS PARQUET".format(
+            test_credentials.eu_result_location
+        )
+    )
     sqlClient_eu.wait_for_job(jobId)
     result_df = sqlClient_eu.get_result(jobId)
-    print("jobId {} restults are stored in {}. Result set is:".format(jobId, sqlClient_eu.get_job(jobId)['resultset_location']))
+    print(
+        "jobId {} restults are stored in {}. Result set is:".format(
+            jobId, sqlClient_eu.get_job(jobId)["resultset_location"]
+        )
+    )
     print(result_df.head(200))
     print("EU SQL UI Link:")
     sqlClient_eu.sql_ui_link()
@@ -269,17 +395,27 @@ except AttributeError as _:
 print("Force rate limiting:")
 try:
     for n in range(6):
-        sqlClient.submit_sql("SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS PARQUET".format(test_credentials.result_location))
-except RateLimitedException as e:
+        sqlClient.submit_sql(
+            "SELECT * FROM cos://us-geo/sql/employees.parquet STORED AS PARQUET LIMIT 10 INTO {} STORED AS PARQUET".format(
+                test_credentials.result_location
+            )
+        )
+except RateLimitedException:
     print("Got rate limited as expected")
 
 
 # add this as the previous test launches so many asynchronous runs
-sqlClient = ibmcloudsql.SQLQuery(test_credentials.apikey, test_credentials.instance_crn, target_cos_url=test_credentials.result_location, client_info='ibmcloudsql test', max_tries=100)
+sqlClient = ibmcloudsql.SQLQuery(
+    test_credentials.apikey,
+    test_credentials.instance_crn,
+    target_cos_url=test_credentials.result_location,
+    client_info="ibmcloudsql test",
+    max_tries=100,
+)
 sqlClient.logon()
 print("Running test with execute_sql() no data returned:")
 result = sqlClient.execute_sql(
-"WITH orders_shipped AS \
+    "WITH orders_shipped AS \
   (SELECT OrderID, EmployeeID, (CASE WHEN shippedDate < requiredDate \
                                    THEN 'On Time' \
                                    ELSE 'Late' \
@@ -291,7 +427,10 @@ FROM orders_shipped o, \
 WHERE e.EmployeeID = o.EmployeeID \
 GROUP BY e.FirstName, e.LastName, Shipped \
 ORDER BY e.LastName, e.FirstName, NumOrders DESC \
-INTO {} STORED AS CSV".format(test_credentials.result_location))
+INTO {} STORED AS CSV".format(
+        test_credentials.result_location
+    )
+)
 print("Result is:")
 print(result)
 # ========= CATALOG TABLES
@@ -322,28 +461,39 @@ print("Drop a catalog table")
 print(sqlClient.drop_table(table_name))
 print(sqlClient.show_tables())
 
-# ============= SQLMagic
+# ============= SQLBuilder
 print("==================================")
 print("Check query string generation")
-sqlmagic = ibmcloudsql.SQLMagic()
+sqlmagic = ibmcloudsql.SQLBuilder()
 targeturl = "cos://us-geo/thinkstdemo-donotdelete-pr-iwmvg18vv9ki4d/"
-(sqlClient.with_("humidity_location_table",
-                     (sqlmagic.select_("location")
-                             .from_view_("select count(*) as count, location from dht where humidity > 70.0 group by location")
-                             .where_("count > 1000 and count < 2000")
-                     ).reset_()
-                )
-    .with_("pm_location_table",
-                     (sqlmagic.select_("location")
-                             .from_view_("select count(*) as count, location from sds group by location")
-                             .where_("count > 1000 and count < 2000")
-                     ).reset_()
+(
+    sqlClient.with_(
+        "humidity_location_table",
+        (
+            sqlmagic.select_("location")
+            .from_view_(
+                "select count(*) as count, location from dht where humidity > 70.0 group by location"
             )
+            .where_("count > 1000 and count < 2000")
+        ).reset_(),
+    )
+    .with_(
+        "pm_location_table",
+        (
+            sqlmagic.select_("location")
+            .from_view_("select count(*) as count, location from sds group by location")
+            .where_("count > 1000 and count < 2000")
+        ).reset_(),
+    )
     .select_("humidity_location_table.location")
     .from_table_("humidity_location_table")
-    .join_table_("pm_location_table", type="inner", condition="humidity_location_table.location=pm_location_table.location")
-    .store_at_(targeturl)
+    .join_table_(
+        "pm_location_table",
+        typ="inner",
+        condition="humidity_location_table.location=pm_location_table.location",
     )
+    .store_at_(targeturl)
+)
 expected_sql = """WITH humidity_location_table AS
   (SELECT LOCATION
    FROM
@@ -365,25 +515,32 @@ expected_sql = """WITH humidity_location_table AS
      AND COUNT < 2000 )
 SELECT humidity_location_table.location
 FROM humidity_location_table
-INNER JOIN pm_location_table ON humidity_location_table.location=pm_location_table.location INTO cos://us-geo/thinkstdemo-donotdelete-pr-iwmvg18vv9ki4d/ STORED AS CSV"""
-assert(sqlClient.get_sql() == expected_sql)
+INNER JOIN pm_location_table ON humidity_location_table.location=pm_location_table.location
+INTO cos://us-geo/thinkstdemo-donotdelete-pr-iwmvg18vv9ki4d/ STORED AS CSV"""
+assert sqlClient.get_sql() == expected_sql
 
 print("==================================")
 print("Check generating JOIN statement")
 try:
-    (sqlClient
-        .join_table_("pm_location_table", type="inner a", condition="humidity_location_table.location=pm_location_table.location")
+    (
+        sqlClient.join_table_(
+            "pm_location_table",
+            typ="inner a",
+            condition="humidity_location_table.location=pm_location_table.location",
+        )
     )
 except ValueError:
     print("Got ValueError as expected")
 except Exception:
-    assert(0)
+    assert 0
 
 print("==================================")
 print("Check get_schema_data")
 try:
-    df = sqlClient.get_schema_data("cos://us-geo/sql/oklabdata/parquet/sds011/2017/09/", type="csv")
+    df = sqlClient.get_schema_data(
+        "cos://us-geo/sql/oklabdata/parquet/sds011/2017/09/", typ="csv"
+    )
 except ValueError:
     print("Got ValueError as expected")
 except Exception:
-    assert(0)
+    assert 0

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
+"""Setup file."""
 import codecs
 import os.path
 
@@ -20,18 +21,20 @@ from setuptools import setup
 
 
 def readme():
+    """Return README.rst content."""
     with open("README.rst") as f:
         return f.read()
 
 
-def read(rel_path):
+def _read(rel_path):
     here = os.path.abspath(os.path.dirname(__file__))
     with codecs.open(os.path.join(here, rel_path), "r") as fp:
         return fp.read()
 
 
 def get_version(rel_path):
-    for line in read(rel_path).splitlines():
+    """Get package version."""
+    for line in _read(rel_path).splitlines():
         if line.startswith("__version__"):
             delim = '"' if '"' in line else "'"
             return line.split(delim)[1]
@@ -46,8 +49,8 @@ setup(
     install_requires=[
         "pandas",
         "requests>= 2.2.0",
-        "ibm-cos-sdk-core>=2.7.0",
-        "ibm-cos-sdk>=2.7.0",
+        "ibm-cos-sdk-core==2.10.0",
+        "ibm-cos-sdk==2.10.0",
         "numpy",
         "pyarrow==0.16.0",
         "backoff==1.10.0",
@@ -58,7 +61,7 @@ setup(
         "importlib-metadata",
         "typing-extensions",
     ],
-    description="Python client for interacting with IBM Cloud SQL Query service",
+    description="Python client for interacting with IBM Cloud SQL Query service",  # noqa
     url="https://github.com/IBM-Cloud/sql-query-clients",
     author="IBM Corp.",
     author_email="torsten@de.ibm.com",


### PR DESCRIPTION
* change name from SQLMagic to SQLBuilder
* update SQLBuilder: generate 'FIELD TERMINATED BY ' in `.from_cos_` API
* update SQLClientTimeSeries: work with either catalog table or COS URL as datasource
* update TimeSeriesTransformInput: support more units (minute, Xminute)
* update COSClient: add `copy_objects`
* fix bug COSClient: `list_cos_objects`
* fix bug HiveMetastore: `create_partitioned_table`
* update HiveMetastore: add `add_partitions`
* update SQLQuery: add the option to specify format when using default target cos url, thread-safe writing checkpoint file  when using `submit_and_track_sql`