### PR TITLE
Fix upload issue to cos while copying objects

### DIFF
--- a/Python/ibmcloudsql/cos.py
+++ b/Python/ibmcloudsql/cos.py
@@ -1155,8 +1155,9 @@ class COSClient(ParsedUrl, IBMCloudAccess):
         url_parsed = self.analyze_cos_url(cos_url)
         cos_client = self._get_cos_client(url_parsed.endpoint)
         bucket = url_parsed.bucket
+        key = url_parsed.prefix
         try:
-            res = cos_client.upload_file(source_path, bucket, cos_url)
+            res = cos_client.upload_file(source_path, bucket, key)
         except Exception as e:
             print(Exception, e)
         else:

--- a/Python/ibmcloudsql/cos.py
+++ b/Python/ibmcloudsql/cos.py
@@ -1156,7 +1156,7 @@ class COSClient(ParsedUrl, IBMCloudAccess):
         cos_client = self._get_cos_client(url_parsed.endpoint)
         bucket = url_parsed.bucket
         try:
-            res = cos_client.upload_file(source_path, cos_url)
+            res = cos_client.upload_file(source_path, bucket, cos_url)
         except Exception as e:
             print(Exception, e)
         else:


### PR DESCRIPTION
Observed that `copy_objects` fails while uploading to COS as bucket info wasn't passed. 

The [upload_file](https://ibm.github.io/ibm-cos-sdk-python/_modules/ibm_boto3/s3/transfer.html#S3Transfer.upload_file) API endpoint from `ibm_boto3` library take params as bucket and key and they needs to be passed correctly.